### PR TITLE
Kp, Kd, Ki values are not clippied anymore

### DIFF
--- a/ROAR/control_module/pid_controller.py
+++ b/ROAR/control_module/pid_controller.py
@@ -47,7 +47,7 @@ class PIDController(Controller):
             if current_speed < speed_upper_bound:
                 k_p, k_d, k_i = kvalues["Kp"], kvalues["Kd"], kvalues["Ki"]
                 break
-        return np.clip([k_p, k_d, k_i], a_min=0, a_max=1)
+        return np.clip(k_p, k_d, k_i)
 
 
 class LongPIDController(Controller):

--- a/ROAR/control_module/pid_controller.py
+++ b/ROAR/control_module/pid_controller.py
@@ -125,6 +125,7 @@ class LatPIDController(Controller):
         w_vec_normed = w_vec / np.linalg.norm(w_vec)
         error = np.arccos(v_vec_normed @ w_vec_normed.T)
         _cross = np.cross(v_vec_normed, w_vec_normed)
+        
         if _cross[1] > 0:
             error *= -1
         self._error_buffer.append(error)
@@ -140,9 +141,5 @@ class LatPIDController(Controller):
         lat_control = float(
             np.clip((k_p * error) + (k_d * _de) + (k_i * _ie), self.steering_boundary[0], self.steering_boundary[1])
         )
-        # print(f"v_vec_normed: {v_vec_normed} | w_vec_normed = {w_vec_normed}")
-        # print("v_vec_normed @ w_vec_normed.T:", v_vec_normed @ w_vec_normed.T)
-        # print(f"Curr: {self.agent.vehicle.transform.location}, waypoint: {next_waypoint}")
-        # print(f"lat_control: {round(lat_control, 3)} | error: {error} ")
-        # print()
+        
         return lat_control


### PR DESCRIPTION
# Pull Request Template

## Description

np.clip is applied on Kp, Ki, Kd raw coefficients in find_k_values function.
np.clip is used in 33 places in 11 files. These need to be checked as well.

Fixes # 52

## Type of change
- [V ] Bug fix (non-breaking change which fixes an issue)#52 